### PR TITLE
Fix for CWE-307: Improper Restriction of Excessive Authentication Attempts

### DIFF
--- a/bad/mod_user.py
+++ b/bad/mod_user.py
@@ -1,7 +1,10 @@
+import time
 from flask import Blueprint, render_template, redirect, request, g, session, make_response, flash
 import libmfa
 import libuser
 import libsession
+# In-memory dict for login throttling: {(username, ip): [fail_count, first_fail_time, lockout_until]}
+failed_logins = {}
 
 mod_user = Blueprint('mod_user', __name__, template_folder='templates')
 
@@ -11,19 +14,48 @@ def do_login():
 
     session.pop('username', None)
 
+    MAX_ATTEMPTS = 5
+    LOCKOUT_TIME = 300  # seconds (5 minutes)
+    client_ip = request.remote_addr
     if request.method == 'POST':
 
+        if username:
+            key = (username, client_ip)
+            now = time.time()
+            attempts = failed_logins.get(key, [0, 0, 0])
+            # Check active lockout
+            if attempts[2] > now:
+                flash("Too many failed login attempts. Please try again later.")
+                return render_template('user.login.mfa.html')
         username = request.form.get('username')
         password = request.form.get('password')
         otp = request.form.get('otp')
 
-        username = libuser.login(username, password)
+        valid_user = libuser.login(username, password)
 
-        if not username:
-            flash("Invalid user or password");
+        if not valid_user:
+            # Record failed login
+            if username:
+                fail_count, first_fail, lock_until = attempts
+                if fail_count == 0 or now > first_fail + LOCKOUT_TIME:
+                    # Reset fail window
+                    failed_logins[key] = [1, now, 0]
+                else:
+                    fail_count += 1
+                    lockout = 0
+                    if fail_count >= MAX_ATTEMPTS:
+                        lockout = now + LOCKOUT_TIME
+                        flash("Too many failed login attempts. Please try again later.")
+                        failed_logins[key] = [fail_count, first_fail, lockout]
+                        return render_template('user.login.mfa.html')
+                    failed_logins[key] = [fail_count, first_fail, 0]
+            flash("Invalid user or password")
             return render_template('user.login.mfa.html')
 
-        if libmfa.mfa_is_enabled(username):
+        # On successful login, reset failed count for this user/ip
+        if username:
+            failed_logins.pop(key, None)
+        username = valid_user
             if not libmfa.mfa_validate(username, otp):
                 flash("Invalid OTP");
                 return render_template('user.login.mfa.html')


### PR DESCRIPTION
🐕 [Corgea](https://www.corgea.com) issued a PR to fix a vulnerability found in bad/mod_user.py.

It is CWE-307: Improper Restriction of Excessive Authentication Attempts that has a severity of :orange_circle: Medium.

### 🪄 Fix explanation
The fix adds a login attempt tracking mechanism that limits login attempts to 5 within a 5-minute window, mitigating brute force attacks by temporarily locking accounts after consecutive failures.<br>- An in-memory dictionary &quot;failed_logins&quot; tracks failed login attempts per user and IP.<br>    - Introduced constants &quot;MAX_ATTEMPTS&quot; and &quot;LOCKOUT_TIME&quot; to define thresholds for attempts and lockout duration.<br>    - On each failed login, the user/IP pair is recorded, and the failed attempt count is incremented.<br>    - If &quot;MAX_ATTEMPTS&quot; is exceeded within &quot;LOCKOUT_TIME&quot;, further login attempts are disabled temporarily.<br>    - On successful login, the failed attempt record for that user/IP is cleared, preventing unnecessary lockouts.

### 💡 Important Instructions
Ensure that sessions or server restarts do not clear the <code>failed_logins</code> dictionary; consider persistent storage for production use.

[See the issue and fix in Corgea.](https://www.corgea.app/issue/caf7ccd6-1f31-426d-90e1-7d06d9af1aca)

